### PR TITLE
network生成モジュールを追加

### DIFF
--- a/src/sampling/main.jl
+++ b/src/sampling/main.jl
@@ -20,9 +20,9 @@ function main(args)
         arg_type = Int
         "--omega"
         help = "weight parameter of the network"
-        "--alpha"
         default = - 0.99
         arg_type = Float64
+        "--alpha"
         help = "Exponent parameter alpha"
         default = 0.99 # 1 - epsilon
         arg_type = Float64
@@ -40,7 +40,7 @@ function main(args)
     println("N = $(int_to_SI_prefix(N)), T = $(int_to_SI_prefix(T)), r = $(int_to_SI_prefix(r)), omega = $(omega), alpha = $(alpha)")
 
     # Run the simulation
-    Z = simulate_ants(N, T, r, omega, alpha)
+    Z = Simulation.simulate_ants(N, T, r, omega, alpha)
 
     # Output Z values to CSV
     dir_Z = "data/Zt"

--- a/src/sampling/network.jl
+++ b/src/sampling/network.jl
@@ -1,0 +1,77 @@
+module Network
+
+using Random, ProgressMeter, StatsBase
+
+function initialize_network(T::Int, r::Int)
+    k_in = zeros(Int, T)
+    k_out = zeros(Int, T)
+
+    for t in 1:(r + 1)
+        k_in[t] = r
+        k_out[t] = (r + 1) - t
+    end
+
+    return k_in, k_out
+end
+
+function generate_network(T::Int, r::Int, w::Float64)
+    if w == -1.0
+        return network_lattice(T, r)
+    else
+        return network_popularity(T, r, w)
+    end
+end
+
+function network_popularity(T::Int, r::Int, w::Float64)
+    # 初期条件の設定
+    k_in, k_out = initialize_network(T, r)
+    l = zeros(Float64, T)
+
+    progressBar = Progress(T, 1, "Evoluting network")
+
+    # ネットワークの進化
+    for t in (r + 2):T
+        k_in[t] = r
+        # 人気度の更新（負の値を0に置き換える）
+        l .= max.(0, k_in .+ w .* k_out)
+
+        # 人気度が0より大きいアリを選択可能なリストに追加
+        popular_ants = findall(x -> x > 0, l)
+
+        # 人気度の合計
+        total_popularity = sum(l[popular_ants])
+
+        # 既存のノードから r または r' アリを選択
+        num_links = min(r, length(popular_ants))
+
+        # 重み付きサンプリングでアリを選択
+        probabilities = l[popular_ants] / total_popularity
+        selected_ants = sample(popular_ants, Weights(probabilities), num_links, replace=false)
+
+        # 選ばれたアリの k_out を更新
+        k_out[selected_ants] .+= 1
+        next!(progressBar)
+    end
+
+    return k_out
+end
+
+function network_lattice(T::Int, r::Int)
+    # 初期条件の設定
+    k_in, k_out = initialize_network(T, r)
+
+    # ネットワークの進化
+    for t in (r + 2):T
+        k_in[t] = r
+
+        # 既存のノードの出次数を更新
+        k_out[1:max(1, t - r - 1)] .= r
+        if t - r > 0
+            k_out[(t - r):(t - 1)] .= (r - 1):-1:0
+        end
+    end
+
+    return k_out
+end
+
+end

--- a/src/sampling/output.jl
+++ b/src/sampling/output.jl
@@ -1,7 +1,7 @@
 using CSV, DataFrames
 
 # Convert the numeric value to a string format with K, M, G, etc.
-function format_num(value::Int)
+function int_to_SI_prefix(value::Int)
     if value % 1_000_000_000 == 0
         return string(value ÷ 1_000_000_000) * "G"
     elseif value % 1_000_000 == 0

--- a/src/sampling/simulation.jl
+++ b/src/sampling/simulation.jl
@@ -2,6 +2,8 @@ module Simulation
 
 using Random, ProgressMeter
 
+include("network.jl")
+
 const DEFAULT_EPSILON = 0.01  # Define epsilon as a constant at the top of the code
 
 # Decision function f(z)
@@ -9,9 +11,9 @@ function decision_function(Zj::Vector{Float64}, alpha::Float64, epsilon::Float64
     return (1 - epsilon) * ((Zj.^alpha) ./ (Zj.^alpha .+ (1 .- Zj).^alpha)) .+ 0.5 * epsilon
 end
 
-# Initialize the simulation up to the initial time t0.
-function initialize_simulation(N::Int, X::Vector{Int}, S::Vector{Float64}, Sj::Vector{Float64}, t0::Int, k_out::Vector{Int})
-    for t in 1:t0
+# Initialize the simulation up to the initial time r.
+function initialize_simulation(N::Int, X::Vector{Int}, S::Vector{Float64}, Sj::Vector{Float64}, r::Int, k_out::Vector{Int})
+    for t in 1:r
         X .= rand(0:1, N)
         TP = sum(X)
         S[t] = (t == 1 ? TP : S[t-1] + TP * k_out[t])
@@ -23,15 +25,15 @@ end
 function simulate_ants(N::Int, T::Int, r::Int, w::Float64, alpha::Float64)
     X = zeros(Int, N)
     Sj = zeros(Float64, N)
-    S = zeros(Float64, T + t0)
+    S = zeros(Float64, T + r)
 
     # network_popularity関数からk_out配列を取得
-    k_out = network(T, r, w)
+    k_out = Network.generate_network(T, r, w)
 
     # Initialization
     initialize_simulation(N, X, S, Sj, r, k_out)
 
-    for t in (t0 + 1):(t0 + T)
+    for t in (r + 1):(r + T)
         Zj = Sj ./ S[t-1]
         prob = decision_function(Zj, alpha, DEFAULT_EPSILON)
         X .= rand(Float64, N) .< prob


### PR DESCRIPTION
## 概要
このプルリクエストでは、新しい `Network` モジュールを追加しました。このモジュールは、ネットワークの生成と進化をシミュレートするための関数群を提供します。

## 主な機能
- `initialize_network` 関数: ネットワークの初期化を行います。
- `generate_network` 関数: ネットワークのタイプに基づいて、適切なネットワーク生成関数を呼び出します。
- `network_popularity` 関数: 人気度に基づいてネットワークを進化させます。
- `network_lattice` 関数: 拡張ラティスケースに対応したネットワークを生成します。

## ネットワークモデルの定義
#5 