### PR TITLE
シミュレーションのサンプリング対応

### DIFF
--- a/src/sampling/main.jl
+++ b/src/sampling/main.jl
@@ -44,21 +44,15 @@ function main(args)
     println("N = $(int_to_SI_prefix(N)), T = $(int_to_SI_prefix(T)), r = $(int_to_SI_prefix(r)), omega = $(omega), alpha = $(alpha)")
 
     # Run the simulation
-    Z, link_matrix = Simulation.simulate_ants(N, T, r, omega, alpha)
+    Z = Simulation.simulate_ants(N, T, r, omega, alpha)
 
     # Output Z values to CSV
     dir_Z = "data/Zt"
-    dir_link = "data/link_matrix"
     if !isdir(dir_Z)
         mkpath(dir_Z)
     end
-    if !isdir(dir_link)
-        mkpath(dir_link)
-    end
     filename_Z = joinpath(dir_Z, "N$(int_to_SI_prefix(N))_T$(int_to_SI_prefix(T))_r$(int_to_SI_prefix(r))_omega$(omega)_alpha$(alpha).csv")
     save_Z_to_csv(Z, filename_Z)
-    filename_link = joinpath(dir_link, "N$(int_to_SI_prefix(N))_T$(int_to_SI_prefix(T))_r$(int_to_SI_prefix(r))_omega$(omega)_alpha$(alpha).csv")
-    save_link_matrix_to_csv(link_matrix, filename_link)
     end
 
 # Entry point of the script

--- a/src/sampling/main.jl
+++ b/src/sampling/main.jl
@@ -18,7 +18,7 @@ function main(args)
 
         "--r"
         help = "Initial number of ants"
-        default = 1000
+        default = 100
         arg_type = Int
 
         "--omega"
@@ -28,8 +28,14 @@ function main(args)
 
         "--alpha"
         help = "Exponent parameter alpha"
-        default = 1.01 # 1 - epsilon
+        default = 1.01 # 1/(1 - epsilon)
         arg_type = Float64
+
+        "--sample"
+        help = "Sample size."
+        default = 100
+        arg_type = Int
+
     end
 
     parsed_args = parse_args(args, s)
@@ -38,13 +44,14 @@ function main(args)
     r = parsed_args["r"]
     omega = parsed_args["omega"]
     alpha = parsed_args["alpha"]
+    samples = parsed_args["sample"]
 
     # Log the simulation parameters
     println("Running simulation with the following parameters:")
-    println("N = $(int_to_SI_prefix(N)), T = $(int_to_SI_prefix(T)), r = $(int_to_SI_prefix(r)), omega = $(omega), alpha = $(alpha)")
+    println("N = $(int_to_SI_prefix(N)), T = $(int_to_SI_prefix(T)), r = $(int_to_SI_prefix(r)), omega = $(omega), alpha = $(alpha), samples = $(int_to_SI_prefix(samples))")
 
     # Run the simulation
-    Z = Simulation.simulate_ants(N, T, r, omega, alpha)
+    Z_mean, Z_std = Simulation.sample_ants(N, T, r, omega, alpha, samples)
 
     # Output Z values to CSV
     dir_Z = "data/Zt"
@@ -52,7 +59,7 @@ function main(args)
         mkpath(dir_Z)
     end
     filename_Z = joinpath(dir_Z, "N$(int_to_SI_prefix(N))_T$(int_to_SI_prefix(T))_r$(int_to_SI_prefix(r))_omega$(omega)_alpha$(alpha).csv")
-    save_Z_to_csv(Z, filename_Z)
+    save_Z_to_csv(Z_mean, Z_std, filename_Z)
     end
 
 # Entry point of the script

--- a/src/sampling/network.jl
+++ b/src/sampling/network.jl
@@ -1,6 +1,6 @@
 module Network
 
-using Random, ProgressMeter, StatsBase
+using Random, StatsBase
 
 function initialize_network(T::Int, r::Int)
     k_in = zeros(Int, T)
@@ -18,25 +18,23 @@ function initialize_network(T::Int, r::Int)
     return k_in, k_out, link_matrix
 end
 
-function generate_network(T::Int, r::Int, w::Float64)
-    if w == -1.0
+function generate_network(T::Int, r::Int, omega::Float64)
+    if omega == -1.0
         return network_lattice(T, r)
     else
-        return network_popularity(T, r, w)
+        return network_popularity(T, r, omega)
     end
 end
 
-function network_popularity(T::Int, r::Int, w::Float64)
+function network_popularity(T::Int, r::Int, omega::Float64)
     # 初期条件の設定
     k_in, k_out, link_matrix = initialize_network(T, r)
     l = zeros(Float64, T)
 
-    progressBar = Progress(T-(r+2), 1, "Evoluting network")
-
     # ネットワークの進化
     for t in (r + 2):T
         # 人気度の更新
-        l .= k_in .+ w .* k_out
+        l .= k_in .+ omega .* k_out
 
         # 人気度が0より大きいアリを選択可能なリストに追加
         popular_ants = findall(x -> x > 0, l)
@@ -58,8 +56,6 @@ function network_popularity(T::Int, r::Int, w::Float64)
             k_out[ant] += 1
             k_in[t] += 1
         end
-
-        next!(progressBar)
     end
 
     return k_in, k_out, link_matrix

--- a/src/sampling/output.jl
+++ b/src/sampling/output.jl
@@ -14,9 +14,9 @@ function int_to_SI_prefix(value::Int)
 end
 
 # Function to save Z values to a CSV file with optional downsampling
-function save_Z_to_csv(Z::Vector{Float64}, filename::String)
-    t_values = collect(1:length(Z))
-    df = DataFrame(t=t_values, Z=Z)
+function save_Z_to_csv(Z_mean::Vector{Float64}, Z_std::Vector{Float64}, filename::String)
+    t_values = collect(1:length(Z_mean))
+    df = DataFrame(t=t_values, Z=Z_mean, std=Z_std)
     CSV.write(filename, df)
     println("Saved Z values to $filename")
 end

--- a/src/sampling/output.jl
+++ b/src/sampling/output.jl
@@ -20,10 +20,3 @@ function save_Z_to_csv(Z::Vector{Float64}, filename::String)
     CSV.write(filename, df)
     println("Saved Z values to $filename")
 end
-
-# Function to save the link matrix to a CSV file
-function save_link_matrix_to_csv(link_matrix::Matrix{Int}, filename::String)
-    df = DataFrame(link_matrix, :auto)
-    CSV.write(filename, df)
-    println("Saved link matrix to $filename")
-end

--- a/src/sampling/simulation.jl
+++ b/src/sampling/simulation.jl
@@ -52,7 +52,7 @@ function simulate_ants(N::Int, T::Int, r::Int, w::Float64, alpha::Float64)
 
     Z = S ./ (r * N)
 
-    return Z, link_matrix
+    return Z
 
 end
 


### PR DESCRIPTION
### 概要
並列処理のサンプリングメソッドを作成し、Zの平均値と標準偏差を返すように設計した。それに伴いリンク行列を返り値から削除した。

### 動作確認
Zの平均値と標準偏差をプロットした様子（サンプル数100）
![各ωのZ(t)の時間変化プロット](https://github.com/LABO-M/ACO-on-Network/assets/83319786/b9351259-28b1-4fd5-8f68-a14cc7833d2f)
